### PR TITLE
Bump 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,67 @@
 ---
+
 language: python
 python: "2.7"
+
+matrix:
+  include:
+    - dist: precise
+      env: LOGSTASH_VERSION=1.5 UBUNTU_VER=12.04 NEXT_LOGSTASH_VERSION=2.0
+    - dist: precise
+      env: LOGSTASH_VERSION=2.0 UBUNTU_VER=12.04 NEXT_LOGSTASH_VERSION=2.1
+    - dist: precise
+      env: LOGSTASH_VERSION=2.1 UBUNTU_VER=12.04 NEXT_LOGSTASH_VERSION=2.2
+    - dist: precise
+      env: LOGSTASH_VERSION=2.2 UBUNTU_VER=12.04 NEXT_LOGSTASH_VERSION=2.3
+    - dist: precise
+      env: LOGSTASH_VERSION=2.3 UBUNTU_VER=12.04 NEXT_LOGSTASH_VERSION=2.4
+    - dist: precise
+      env: LOGSTASH_VERSION=2.4 UBUNTU_VER=12.04 NEXT_LOGSTASH_VERSION=5.0
+    - dist: precise
+      env: LOGSTASH_VERSION=5.0 UBUNTU_VER=12.04 NEXT_LOGSTASH_VERSION=''
+    - dist: trusty
+      env: LOGSTASH_VERSION=1.5 UBUNTU_VER=14.04 NEXT_LOGSTASH_VERSION=2.0
+    - dist: trusty
+      env: LOGSTASH_VERSION=2.0 UBUNTU_VER=14.04 NEXT_LOGSTASH_VERSION=2.1
+    - dist: trusty
+      env: LOGSTASH_VERSION=2.1 UBUNTU_VER=14.04 NEXT_LOGSTASH_VERSION=2.2
+    - dist: trusty
+      env: LOGSTASH_VERSION=2.2 UBUNTU_VER=14.04 NEXT_LOGSTASH_VERSION=2.3
+    - dist: trusty
+      env: LOGSTASH_VERSION=2.3 UBUNTU_VER=14.04 NEXT_LOGSTASH_VERSION=2.4
+    - dist: trusty
+      env: LOGSTASH_VERSION=2.4 UBUNTU_VER=14.04 NEXT_LOGSTASH_VERSION=5.0
+    - dist: trusty
+      env: LOGSTASH_VERSION=5.0 UBUNTU_VER=14.04 NEXT_LOGSTASH_VERSION=''
+  exclude:
+    - python: "2.7"
+
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq python-apt python-pycurl openjdk-7-jre-headless
+ - sudo apt-get install -qq python-apt python-pycurl
+ - if [[ "$_system_version" == "12.04" ]]; then
+        if [[ "$LOGSTASH_VERSION" == "5.0" ]] || [[ "$NEXT_LOGSTASH_VERSION" == "5.0" ]]; then
+            sudo apt-get install -y oracle-java8-installer;
+            export JAVA_HOME=/usr/lib/jvm/java-8-oracle;
+        else
+            sudo apt-get install -y openjdk-7-jre-headless;
+        fi
+   fi
+   # workaround, before https://github.com/travis-ci/travis-ci/issues/6928;
+ - if [[ "$_system_version" == "14.04" ]]; then
+        sudo ln -s /usr/lib/jvm/java-8-oracle /usr/lib/jvm/java-8-oracle-amd64;
+   fi
+ - printenv
 install:
   - pip install ansible
 script:
   - echo localhost > inventory
   - ansible-playbook --syntax-check -i inventory test.yml
-  - ansible-playbook -i inventory test.yml --connection=local --sudo
+  - ansible-playbook -i inventory --connection=local test.yml --sudo -vvvv
+                     -e logstash_version=$LOGSTASH_VERSION
+  - ansible-playbook -i inventory --connection=local test.yml --sudo -vvvv
+                     -e logstash_version=$LOGSTASH_VERSION
+  - if [[ "$NEXT_LOGSTASH_VERSION" != '' ]]; then
+        ansible-playbook -i inventory --connection=local test.yml --sudo -vvvv
+                         -e logstash_version=$NEXT_LOGSTASH_VERSION;
+    fi

--- a/README.md
+++ b/README.md
@@ -59,27 +59,79 @@ Role Variables
 --------------
 
 ```yaml
+# Increase Java performace
+# http://stackoverflow.com/questions/137212/how-to-solve-performance-problem-with-java-securerandom
+logstash_java_opts: "-Djava.security.egd=file:/dev/./urandom"
+
 logstash_python_utils:
  - { package: "python-pycurl" }
  - { package: "python-apt" }
 
-logstash_version: "none"
+# Custom vars for backward compatibility
+logstash_custom_vars:
+    - {
+        version: ["5.0"],
+        apt_repo: "deb https://artifacts.elastic.co/packages/5.x/apt stable main",
+        repo_key: "https://artifacts.elastic.co/GPG-KEY-elasticsearch",
+        new_way_configure: "True",
+        home_dir: "/usr/share/logstash",
+        plugin_bin: "logstash-plugin",
+        config_validate_params: "--path.settings {{ logstash_settings }} -tf %s"
+      }
+    - {
+        version: ["1.5", "2.0", "2.1", "2.2", "2.3", "2.4"],
+        apt_repo: "deb http://packages.elasticsearch.org/logstash/{{ logstash_version }}/debian stable main",
+        repo_key: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch",
+        new_way_configure: "False",
+        home_dir: "/opt/logstash",
+        plugin_bin: "plugin",
+        config_validate_params: "-tf %s"
+      }
 
+# Default vars, if we set the wrong version logstash.
+logstash_version: "2.4"
 logstash_apt_repo: "deb http://packages.elasticsearch.org/logstash/{{ logstash_version }}/debian stable main"
 logstash_repo_key: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch"
+logstash_new_way_configure: "False"
+logstash_home: "/opt/logstash"
+logstash_plugin_bin: "plugin"
+logstash_config_validate_params: "-tf %s"
+
 logstash_yum_repo_dest: "/etc/yum.repos.d/logstash.repo"
 
-logstash_home: "/usr/share/logstash"
-logstash_settings: "/etc/logstash"
-
 logstash_conf_dir: "/etc/logstash/conf.d/"
+logstash_settings: "/etc/logstash"
 logstash_patterns_file: "/etc/logstash/patterns/extra"
-
-logstash_defaults: "LS_HEAP_SIZE="512m""
 
 defaults_RedHat: "/etc/sysconfig/logstash"
 defaults_Debian: "/etc/default/logstash"
+
+# following options are required so logstash can be setup correctly as a 'service'
+logstash_startup_options_service_name: "logstash"
+logstash_startup_options_service_description: "logstash"
+logstash_startup_options_user: "logstash"
+logstash_startup_options_group: "logstash"
+logstash_startup_options_home: "{{ logstash_home }}"
+logstash_startup_options_settings_dir: "{{ logstash_settings }}"
+logstash_startup_options_opts: ""
+logstash_startup_options_nice: 19
+logstash_startup_options_open_files: 16384
+logstash_startup_options_prestart: ""
+
+logstash_plugins:
+  - { plugin_name: "logstash-output-null" }
 ```
+
+Some words
+----------
+
+Available Logstash versions: 1.5, 2.0, 2.1, 2.2, 2.3, 2.4, 5.0
+
+The default is Logstash 2.4.
+
+If the wrong version Logstash will be set - an incorrect repository for Logstash will be added, and the installation will not work.
+
+Because in Logstash 5.0 have been major changes in paths, repositories and other things, we had to introduce the variable **logstash_custom_vars**, which contains specific variables for each version Logstash. This allows us to maintain backward compatibility in the role and easily be updated to version 5.0 (see the current builds status).
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Example Playbooks
     - role: valentinogagliardi.logstash-role
 
       logstash_defaults: |
-        LS_USER=root
         LS_HEAP_SIZE="256m"
-        LS_OPTS="--auto-reload --reload-interval 2"
+        LS_OPTS="-r --config.reload.interval 2"
 
       logstash_patterns: |
         TIMESTAMP_FOO %{MONTHDAY}-%{MONTH}-%{YEAR}-%{HOUR}:%{MINUTE}:%{SECOND}
@@ -70,10 +69,13 @@ logstash_apt_repo: "deb http://packages.elasticsearch.org/logstash/{{ logstash_v
 logstash_repo_key: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch"
 logstash_yum_repo_dest: "/etc/yum.repos.d/logstash.repo"
 
+logstash_home: "/usr/share/logstash"
+logstash_settings: "/etc/logstash"
+
 logstash_conf_dir: "/etc/logstash/conf.d/"
 logstash_patterns_file: "/etc/logstash/patterns/extra"
 
-logstash_defaults: "LS_USER=logstash"
+logstash_defaults: "LS_HEAP_SIZE="512m""
 
 defaults_RedHat: "/etc/sysconfig/logstash"
 defaults_Debian: "/etc/default/logstash"
@@ -88,4 +90,3 @@ Author Information
 ------------------
 
 Valentino Gagliardi - valentino.g@servermanaged.it
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,20 +1,49 @@
 ---
+
 # defaults file for logstash-role
+
+# Increase Java performace
+# http://stackoverflow.com/questions/137212/how-to-solve-performance-problem-with-java-securerandom
+logstash_java_opts: "-Djava.security.egd=file:/dev/./urandom"
 
 logstash_python_utils:
  - { package: "python-pycurl" }
  - { package: "python-apt" }
 
-logstash_version: "5.0"
+# Custom vars for backward compatibility
+logstash_custom_vars:
+    - {
+        version: ["5.0"],
+        apt_repo: "deb https://artifacts.elastic.co/packages/5.x/apt stable main",
+        repo_key: "https://artifacts.elastic.co/GPG-KEY-elasticsearch",
+        new_way_configure: "True",
+        home_dir: "/usr/share/logstash",
+        plugin_bin: "logstash-plugin",
+        config_validate_params: "--path.settings {{ logstash_settings }} -tf %s"
+      }
+    - {
+        version: ["1.5", "2.0", "2.1", "2.2", "2.3", "2.4"],
+        apt_repo: "deb http://packages.elasticsearch.org/logstash/{{ logstash_version }}/debian stable main",
+        repo_key: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch",
+        new_way_configure: "False",
+        home_dir: "/opt/logstash",
+        plugin_bin: "plugin",
+        config_validate_params: "-tf %s"
+      }
 
+# Default vars, if we set the wrong version logstash.
+logstash_version: "2.4"
 logstash_apt_repo: "deb http://packages.elasticsearch.org/logstash/{{ logstash_version }}/debian stable main"
 logstash_repo_key: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch"
+logstash_new_way_configure: "False"
+logstash_home: "/opt/logstash"
+logstash_plugin_bin: "plugin"
+logstash_config_validate_params: "-tf %s"
+
 logstash_yum_repo_dest: "/etc/yum.repos.d/logstash.repo"
 
-logstash_home: "/usr/share/logstash"
-logstash_settings: "/etc/logstash"
-
 logstash_conf_dir: "/etc/logstash/conf.d/"
+logstash_settings: "/etc/logstash"
 logstash_patterns_file: "/etc/logstash/patterns/extra"
 
 defaults_RedHat: "/etc/sysconfig/logstash"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,19 +5,32 @@ logstash_python_utils:
  - { package: "python-pycurl" }
  - { package: "python-apt" }
 
-logstash_version: "2.4"
+logstash_version: "5.0"
 
 logstash_apt_repo: "deb http://packages.elasticsearch.org/logstash/{{ logstash_version }}/debian stable main"
 logstash_repo_key: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch"
 logstash_yum_repo_dest: "/etc/yum.repos.d/logstash.repo"
 
+logstash_home: "/usr/share/logstash"
+logstash_settings: "/etc/logstash"
+
 logstash_conf_dir: "/etc/logstash/conf.d/"
 logstash_patterns_file: "/etc/logstash/patterns/extra"
 
-logstash_defaults: "LS_USER=logstash"
-
 defaults_RedHat: "/etc/sysconfig/logstash"
 defaults_Debian: "/etc/default/logstash"
+
+# following options are required so logstash can be setup correctly as a 'service'
+logstash_startup_options_service_name: "logstash"
+logstash_startup_options_service_description: "logstash"
+logstash_startup_options_user: "logstash"
+logstash_startup_options_group: "logstash"
+logstash_startup_options_home: "{{ logstash_home }}"
+logstash_startup_options_settings_dir: "{{ logstash_settings }}"
+logstash_startup_options_opts: ""
+logstash_startup_options_nice: 19
+logstash_startup_options_open_files: 16384
+logstash_startup_options_prestart: ""
 
 logstash_plugins:
   - { plugin_name: "logstash-output-null" }

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,19 @@
 ---
+
 # handlers file for logstash-role
 
+- name: reenable logstash.service
+  command: systemctl reenable logstash.service
+  when: ansible_service_mgr == 'systemd'
+
 - name: start logstash
-  service: name=logstash
-           state=started
-           enabled=yes
+  service:
+    name: logstash
+    state: started
+    enabled: yes
 
 - name: restart logstash
-  service: name=logstash
-           state=restarted
-           enabled=yes
+  service:
+    name: logstash
+    state: restarted
+    enabled: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -72,7 +72,7 @@ galaxy_info:
   #  - maverick
   #  - natty
   #  - oneiric
-  #  - precise
+    - precise
   #  - quantal
   #  - raring
   #  - saucy

--- a/tasks/logstash_configuration.yml
+++ b/tasks/logstash_configuration.yml
@@ -15,6 +15,8 @@
     owner: root
     group: root
     mode: 0644
+  notify:
+   - restart logstash
 
 - name: Validate and copy Logstash Input Configuration
   environment:
@@ -26,6 +28,8 @@
     group: root
     mode: 0644
     validate: "{{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"
+  notify:
+   - restart logstash
 
 - name: Validate and copy Logstash Filter Configuration
   environment:
@@ -37,6 +41,8 @@
     group: root
     mode: 0644
     validate: "{{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"
+  notify:
+   - restart logstash
 
 - name: Validate and copy Logstash Output Configuration
   environment:
@@ -48,3 +54,5 @@
     group: root
     mode: 0644
     validate: "{{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"
+  notify:
+   - restart logstash

--- a/tasks/logstash_configuration.yml
+++ b/tasks/logstash_configuration.yml
@@ -1,38 +1,50 @@
 ---
+
 - name: Ensure Logstash Patterns Directory Exists
-  file: path={{ logstash_patterns_file|dirname }}
-        state=directory
-        owner=root
-        group=root
-        mode=0755
+  file:
+    path: "{{ logstash_patterns_file|dirname }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
 
 - name: Copy Logstash Patterns Configuration
-  template: src=patterns.j2
-            dest={{ logstash_patterns_file }}
-            owner=root
-            group=root
-            mode=0644
+  template:
+    src: patterns.j2
+    dest: "{{ logstash_patterns_file }}"
+    owner: root
+    group: root
+    mode: 0644
 
 - name: Validate and copy Logstash Input Configuration
-  template: src=input.conf.j2
-            dest={{ logstash_conf_dir }}input.conf
-            owner=root
-            group=root
-            mode=0644
-            validate='{{ logstash_home }}/bin/logstash --path.settings {{ logstash_settings }} -tf %s'
+  environment:
+    JAVA_OPTS: "{{ logstash_java_opts }}"
+  template:
+    src: input.conf.j2
+    dest: "{{ logstash_conf_dir }}input.conf"
+    owner: root
+    group: root
+    mode: 0644
+    validate: "{{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"
 
 - name: Validate and copy Logstash Filter Configuration
-  template: src=filters.conf.j2
-            dest={{ logstash_conf_dir }}filters.conf
-            owner=root
-            group=root
-            mode=0644
-            validate='{{ logstash_home }}/bin/logstash --path.settings {{ logstash_settings }} -tf %s'
+  environment:
+    JAVA_OPTS: "{{ logstash_java_opts }}"
+  template:
+    src: filters.conf.j2
+    dest: "{{ logstash_conf_dir }}filters.conf"
+    owner: root
+    group: root
+    mode: 0644
+    validate: "{{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"
 
 - name: Validate and copy Logstash Output Configuration
-  template: src=output.conf.j2
-            dest={{ logstash_conf_dir }}output.conf
-            owner=root
-            group=root
-            mode=0644
-            validate='{{ logstash_home }}/bin/logstash --path.settings {{ logstash_settings }} -tf %s'
+  environment:
+    JAVA_OPTS: "{{ logstash_java_opts }}"
+  template:
+    src: output.conf.j2
+    dest: "{{ logstash_conf_dir }}output.conf"
+    owner: root
+    group: root
+    mode: 0644
+    validate: "{{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"

--- a/tasks/logstash_configuration.yml
+++ b/tasks/logstash_configuration.yml
@@ -19,7 +19,7 @@
             owner=root
             group=root
             mode=0644
-            validate='/opt/logstash/bin/logstash -tf %s'
+            validate='{{ logstash_home }}/bin/logstash --path.settings {{ logstash_settings }} -tf %s'
 
 - name: Validate and copy Logstash Filter Configuration
   template: src=filters.conf.j2
@@ -27,7 +27,7 @@
             owner=root
             group=root
             mode=0644
-            validate='/opt/logstash/bin/logstash -tf %s'
+            validate='{{ logstash_home }}/bin/logstash --path.settings {{ logstash_settings }} -tf %s'
 
 - name: Validate and copy Logstash Output Configuration
   template: src=output.conf.j2
@@ -35,4 +35,4 @@
             owner=root
             group=root
             mode=0644
-            validate='/opt/logstash/bin/logstash -tf %s'
+            validate='{{ logstash_home }}/bin/logstash --path.settings {{ logstash_settings }} -tf %s'

--- a/tasks/logstash_installation_Debian.yml
+++ b/tasks/logstash_installation_Debian.yml
@@ -1,37 +1,64 @@
 ---
+
 - name: Check whether an update for Logstash is available (Deb)
   shell: 'apt-get update && apt-get upgrade --dry-run'
   register: update_result
   changed_when: "'logstash ' in update_result.stdout" # space character after logstash is important to distinguish available update line from another message.
 
 - name: Stop Logstash before upgrading
-  service: name=logstash
-           state=stopped
-           enabled=yes
+  service:
+    name: logstash
+    state: stopped
+    enabled: yes
   when: update_result.changed
 
+- name: Configure vars basis on Logstash version
+  set_fact:
+    logstash_apt_repo: "{{ item.0.apt_repo }}"
+    logstash_repo_key: "{{ item.0.repo_key }}"
+    logstash_new_way_configure: "{{ item.0.new_way_configure }}"
+    logstash_home: "{{ item.0.home_dir }}"
+    logstash_plugin_bin: "{{ item.0.plugin_bin }}"
+    logstash_config_validate_params: "{{ item.0.config_validate_params }}"
+  with_subelements:
+    - "{{ logstash_custom_vars }}"
+    - version
+  when: item.1 == logstash_version
+
 - name: Enable Logstash Repository
-  apt_repository: repo="{{ logstash_apt_repo }}"
-                  state=present
+  apt_repository:
+    repo: "{{ logstash_apt_repo }}"
+    state: present
 
 - name: Add Logstash Repo Key
-  apt_key: url="{{ logstash_repo_key }}"
-           state=present
+  apt_key:
+    url: "{{ logstash_repo_key }}"
+    state: present
+
+- name: Update cache for use last logstash version
+  apt:
+    update_cache: yes
 
 - name: Install Logstash
-  apt: pkg=logstash
-       update_cache=yes
-       allow_unauthenticated=yes
-       state=latest
+  environment:
+    JAVA_OPTS: "{{ logstash_java_opts }}"
+  apt:
+    pkg: logstash
+    allow_unauthenticated: yes
+    state: latest
+  register: install_logstash
   notify:
+   - reenable logstash.service
    - start logstash
 
 - name: Configure default settings for Logstash
-  template: src=defaults.conf.j2
-            dest={{ defaults_Debian }}
-            owner=root
-            group=root
-            mode=0644
-            backup=yes
+  template:
+    src: defaults.conf.j2
+    dest: "{{ defaults_Debian }}"
+    owner: root
+    group: root
+    mode: 0644
+    backup: yes
   notify:
+   - reenable logstash.service
    - restart logstash

--- a/tasks/logstash_installation_Debian.yml
+++ b/tasks/logstash_installation_Debian.yml
@@ -2,7 +2,7 @@
 - name: Check whether an update for Logstash is available (Deb)
   shell: 'apt-get update && apt-get upgrade --dry-run'
   register: update_result
-  changed_when: "'logstash' in update_result.stdout"
+  changed_when: "'logstash ' in update_result.stdout" # space character after logstash is important to distinguish available update line from another message.
 
 - name: Stop Logstash before upgrading
   service: name=logstash
@@ -21,8 +21,9 @@
 - name: Install Logstash
   apt: pkg=logstash
        update_cache=yes
+       allow_unauthenticated=yes
        state=latest
-  notify: 
+  notify:
    - start logstash
 
 - name: Configure default settings for Logstash

--- a/tasks/logstash_installation_Debian.yml
+++ b/tasks/logstash_installation_Debian.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Check whether an update for Logstash is available (Deb)
-  shell: 'apt-get update && apt-get upgrade --dry-run'
+  shell: 'apt-get upgrade --dry-run'
   register: update_result
   changed_when: "'logstash ' in update_result.stdout" # space character after logstash is important to distinguish available update line from another message.
 

--- a/tasks/logstash_installation_RedHat.yml
+++ b/tasks/logstash_installation_RedHat.yml
@@ -12,18 +12,18 @@
   when: update_result.changed
 
 - name: Enable Logstash repository
-  template: src=logstash_repo.j2 
+  template: src=logstash_repo.j2
             dest={{ logstash_yum_repo_dest }}
 
 - name: Add Logstash Repo Key
-  rpm_key: key="{{ logstash_repo_key }}" 
+  rpm_key: key="{{ logstash_repo_key }}"
            state=present
 
 - name: Install Logstash
   yum: name=logstash
        state=latest
        update_cache=yes
-  notify: 
+  notify:
    - start logstash
 
 - name: Configure default settings for Logstash

--- a/tasks/logstash_installation_RedHat.yml
+++ b/tasks/logstash_installation_RedHat.yml
@@ -1,37 +1,43 @@
 ---
+
 - name: Check whether an update for Logstash is available (RH)
   shell: 'yum makecache && yum check-update || test $? -eq 100'
   when: ansible_pkg_mgr == "yum"
   register: update_result
-  changed_when: "'logstash' in update_result.stdout"
+  changed_when: "'logstash ' in update_result.stdout"
 
 - name: Stop Logstash before upgrading
-  service: name=logstash
-           state=stopped
-           enabled=yes
+  service:
+    name: logstash
+    state: stopped
+    enabled: yes
   when: update_result.changed
 
 - name: Enable Logstash repository
-  template: src=logstash_repo.j2
-            dest={{ logstash_yum_repo_dest }}
+  template:
+    src: logstash_repo.j2
+    dest: "{{ logstash_yum_repo_dest }}"
 
 - name: Add Logstash Repo Key
-  rpm_key: key="{{ logstash_repo_key }}"
-           state=present
+  rpm_key:
+    key: "{{ logstash_repo_key }}"
+    state: present
 
 - name: Install Logstash
-  yum: name=logstash
-       state=latest
-       update_cache=yes
+  yum:
+    name: logstash
+    state: latest
+    update_cache: yes
   notify:
    - start logstash
 
 - name: Configure default settings for Logstash
-  template: src=defaults.conf.j2
-            dest={{ defaults_RedHat }}
-            owner=root
-            group=root
-            mode=0644
-            backup=yes
+  template:
+    src: defaults.conf.j2
+    dest: "{{ defaults_RedHat }}"
+    owner: root
+    group: root
+    mode: 0644
+    backup: yes
   notify:
    - restart logstash

--- a/tasks/logstash_plugins.yml
+++ b/tasks/logstash_plugins.yml
@@ -1,4 +1,4 @@
 
 - name: Install Logstash Plugins
-  command: /opt/logstash/bin/logstash-plugin install {{ item.plugin_name }}
+  command: '{{logstash_home}}/bin/logstash-plugin install {{ item.plugin_name }}'
   with_items: "{{ logstash_plugins }}"

--- a/tasks/logstash_plugins.yml
+++ b/tasks/logstash_plugins.yml
@@ -1,4 +1,7 @@
+---
 
 - name: Install Logstash Plugins
-  command: '{{logstash_home}}/bin/logstash-plugin install {{ item.plugin_name }}'
+  environment:
+    JAVA_OPTS: "{{ logstash_java_opts }}"
+  command: '{{ logstash_home }}/bin/{{ logstash_plugin_bin }} install {{ item.plugin_name }}'
   with_items: "{{ logstash_plugins }}"

--- a/tasks/logstash_requirements.yml
+++ b/tasks/logstash_requirements.yml
@@ -1,7 +1,9 @@
 ---
+
 - name: Install Python utils on Debian OS Family
-  apt: pkg={{ item.package }} 
-       update_cache=yes 
-       state=latest
+  apt:
+    pkg: "{{ item.package }}"
+    update_cache: yes
+    state: latest
   with_items: "{{ logstash_python_utils }}"
   when: ansible_os_family == "Debian"

--- a/tasks/logstash_requirements.yml
+++ b/tasks/logstash_requirements.yml
@@ -1,9 +1,12 @@
 ---
 
+- name: Update cache for use last versions of requirements
+  apt:
+    update_cache: yes
+
 - name: Install Python utils on Debian OS Family
   apt:
     pkg: "{{ item.package }}"
-    update_cache: yes
     state: latest
   with_items: "{{ logstash_python_utils }}"
   when: ansible_os_family == "Debian"

--- a/tasks/logstash_system_install.yml
+++ b/tasks/logstash_system_install.yml
@@ -1,0 +1,27 @@
+
+
+- name: Update startup.options file
+  # because backup option on lineinfile below would create a new backup file each time
+  copy: src="{{ logstash_settings }}/startup.options" dest="{{ logstash_settings }}/startup.options.{{ansible_date_time.iso8601}}" remote_src=yes
+- lineinfile: dest="{{ logstash_settings }}/startup.options" regexp="^({{ item.key }}).*$" line="\1={{ item.value }}" backrefs=yes backup=no
+  with_items:
+    - { key: "SERVICE_NAME", value: "{{logstash_startup_options_service_name}}" }
+    - { key: "SERVICE_DESCRIPTION", value: "{{logstash_startup_options_service_description}}" }
+    - { key: "LS_USER", value: "{{logstash_startup_options_user}}" }
+    - { key: "LS_GROUP", value: "{{logstash_startup_options_group}}" }
+    - { key: "LS_HOME", value: "{{logstash_startup_options_home}}" }
+    - { key: "LS_SETTINGS_DIR", value: "{{logstash_startup_options_settings_dir}}" }
+    - { key: "LS_OPTS", value: "{{logstash_startup_options_opts}}" }
+    - { key: "LS_NICE", value: "{{logstash_startup_options_nice}}" }
+    - { key: "LS_OPEN_FILES", value: "{{logstash_startup_options_open_files}}" }
+
+- blockinfile: dest="{{ logstash_settings }}/startup.options" content="{{ logstash_startup_options_prestart }}" insertbefore="^## EOM" backup=no
+  when: "logstash_startup_options_prestart != ''"
+
+- replace: dest="{{ logstash_settings }}/startup.options" regexp="^## (.*)$" replace="\1" backup=no
+  when: "logstash_startup_options_prestart != ''"
+
+- name: Setup logstash service
+  shell: '{{ logstash_home }}/bin/system-install {{ logstash_settings }}/startup.options'
+  notify:
+   - restart logstash

--- a/tasks/logstash_system_install.yml
+++ b/tasks/logstash_system_install.yml
@@ -1,9 +1,18 @@
-
+---
 
 - name: Update startup.options file
   # because backup option on lineinfile below would create a new backup file each time
-  copy: src="{{ logstash_settings }}/startup.options" dest="{{ logstash_settings }}/startup.options.{{ansible_date_time.iso8601}}" remote_src=yes
-- lineinfile: dest="{{ logstash_settings }}/startup.options" regexp="^({{ item.key }}).*$" line="\1={{ item.value }}" backrefs=yes backup=no
+  copy:
+    src: "{{ logstash_settings }}/startup.options"
+    dest: "{{ logstash_settings }}/startup.options.{{ansible_date_time.iso8601}}"
+    remote_src: yes
+
+- lineinfile:
+    dest: "{{ logstash_settings }}/startup.options"
+    regexp: "^({{ item.key }}).*$"
+    line: "\\1={{ item.value }}"
+    backrefs: yes
+    backup: no
   with_items:
     - { key: "SERVICE_NAME", value: "{{logstash_startup_options_service_name}}" }
     - { key: "SERVICE_DESCRIPTION", value: "{{logstash_startup_options_service_description}}" }
@@ -15,10 +24,18 @@
     - { key: "LS_NICE", value: "{{logstash_startup_options_nice}}" }
     - { key: "LS_OPEN_FILES", value: "{{logstash_startup_options_open_files}}" }
 
-- blockinfile: dest="{{ logstash_settings }}/startup.options" content="{{ logstash_startup_options_prestart }}" insertbefore="^## EOM" backup=no
+- blockinfile:
+    dest: "{{ logstash_settings }}/startup.options"
+    content: "{{ logstash_startup_options_prestart }}"
+    insertbefore: "^## EOM"
+    backup: no
   when: "logstash_startup_options_prestart != ''"
 
-- replace: dest="{{ logstash_settings }}/startup.options" regexp="^## (.*)$" replace="\1" backup=no
+- replace:
+    dest: "{{ logstash_settings }}/startup.options"
+    regexp: "^## (.*)$"
+    replace: "\\1"
+    backup: no
   when: "logstash_startup_options_prestart != ''"
 
 - name: Setup logstash service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,8 @@
   when: ansible_os_family == "RedHat"
   tags: [logstash, logstash-install, logstash-install-redhat]
 
+- include: logstash_system_install.yml
+
 - include: logstash_plugins.yml
 
 - include: logstash_configuration.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+
 # tasks file for logstash-role
 
 - include: logstash_requirements.yml
@@ -13,8 +14,14 @@
   tags: [logstash, logstash-install, logstash-install-redhat]
 
 - include: logstash_system_install.yml
+  when: logstash_new_way_configure == "True"
+  tags: [logstash, logstash-install, logstash-system-install]
 
 - include: logstash_plugins.yml
+  when: install_logstash.changed == "True"
+  tags: [logstash, logstash-install, logstash-plugins]
 
 - include: logstash_configuration.yml
   tags: [logstash, logstash-config, logstash-configuration]
+
+- meta: flush_handlers

--- a/templates/defaults.conf.j2
+++ b/templates/defaults.conf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 LS_HOME="{{ logstash_home }}"
 LS_SETTINGS_DIR="{{ logstash_settings }}"
 {% if logstash_defaults is defined %}

--- a/templates/defaults.conf.j2
+++ b/templates/defaults.conf.j2
@@ -1,3 +1,5 @@
+LS_HOME="{{ logstash_home }}"
+LS_SETTINGS_DIR="{{ logstash_settings }}"
 {% if logstash_defaults is defined %}
 {{ logstash_defaults }}
 {% endif %}

--- a/templates/patterns.j2
+++ b/templates/patterns.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 {% if logstash_patterns is defined %}
 {{ logstash_patterns }}
 {% endif %}

--- a/test.yml
+++ b/test.yml
@@ -3,10 +3,9 @@
   roles:
     - role: logstash-role
       logstash_defaults: |
-        LS_USER=root
         LS_HEAP_SIZE="256m"
-        LS_OPTS="--auto-reload --reload-interval 2"
-      
+        LS_OPTS="-r --config.reload.interval 2"
+
       logstash_inputs: |
         file {
               path => "/var/log/auth.log"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
+
 # vars file for logstash-role


### PR DESCRIPTION
From https://github.com/valentinogagliardi/logstash-role/pull/14

---

Hello!

I took as a basis PR #13 and made the following changes:
- Modify it for backward compatibility with previous versions Logstash.
- Сhanged the formatting the role.
- Added Travis CI to check the installation of all possible versions Logstash on Ubuntu 12.04 and Ubuntu 14.04. Also checked Logstash upgrade to the next version.
  - Build Status (https://travis-ci.org/dekhtyarev/logstash-role/builds/181142782)
  - Manually test the installation versions 2.4 and 5.0 on Ubuntu 16.04 (all good).
  
With the changes in this PR, you can install the required version Logstash and easily support new versions Logstash with serious changes.
 
If the PR more interesting to you - expect to questions and adopting pull request.
If not, I'll use it in my Fork. Maybe someone else will need to upgrade its fleet Logstash servers and he has previously used your role.