### PR TITLE
Add configuration for log4j facility for logstash logs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,3 +71,6 @@ logstash_startup_options_service_name: "logstash"
 logstash_startup_options_service_description: "logstash"
 logstash_startup_options_prestart: ""
 
+# Options for log4j2
+logstash_log4j2_max_files: 10
+logstash_log4j2_filesize: "512 MB"

--- a/tasks/030_logstash_system_install.yml
+++ b/tasks/030_logstash_system_install.yml
@@ -21,3 +21,13 @@
     mode: 0644
   notify:
    - restart logstash
+
+- name: Generate log4j2 properties file
+  template:
+    src: etc/logstash/log4j2.properties.j2
+    dest: "{{ logstash_settings_dir }}log4j2.properties"
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+   - restart logstash

--- a/templates/etc/logstash/log4j2.properties.j2
+++ b/templates/etc/logstash/log4j2.properties.j2
@@ -1,0 +1,32 @@
+status = error
+name = LogstashPropertiesConfig
+
+appender.rolling.type = RollingFile
+appender.rolling.name = plain_rolling
+appender.rolling.fileName = ${sys:ls.logs}/logstash-${sys:ls.log.format}.log
+appender.rolling.filePattern = ${sys:ls.logs}/logstash-${sys:ls.log.format}-%d{yyyy-MM-dd}-%i.log
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = true
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size = {{ logstash_log4j2_filesize }}
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %-.10000m%n
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = {{ logstash_log4j2_max_files }}
+
+appender.json_rolling.type = RollingFile
+appender.json_rolling.name = json_rolling
+appender.json_rolling.fileName = ${sys:ls.logs}/logstash-${sys:ls.log.format}.log
+appender.json_rolling.filePattern = ${sys:ls.logs}/logstash-${sys:ls.log.format}-%d{yyyy-MM-dd}-%i.log
+appender.json_rolling.policies.type = Policies
+appender.json_rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.json_rolling.policies.time.interval = 1
+appender.json_rolling.policies.time.modulate = true
+appender.json_rolling.layout.type = JSONLayout
+appender.json_rolling.layout.compact = true
+appender.json_rolling.layout.eventEol = true
+
+rootLogger.level = ${sys:ls.log.level}
+rootLogger.appenderRef.rolling.ref = ${sys:ls.log.format}_rolling


### PR DESCRIPTION
Add the configuration for log4j2 with time-based and size-based triggering.
Log file will be rotated on next conditions:
1) end of day.
2) Size of file based on {{ logstash_log4j2_filesize }}
Also logstash will keep last {{ logstash_log4j2_max_files }}  files.