### PR TITLE
add validation environments to template tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ logstash_new_way_configure: "False"
 logstash_home: "/opt/logstash"
 logstash_plugin_bin: "plugin"
 logstash_config_validate_params: "-tf %s"
+logstash_config_validate_envs: ""
 
 logstash_yum_repo_dest: "/etc/yum.repos.d/logstash.repo"
 

--- a/tasks/050_logstash_pipeline_configuration.yml
+++ b/tasks/050_logstash_pipeline_configuration.yml
@@ -27,7 +27,7 @@
     owner: root
     group: root
     mode: 0644
-    validate: "{{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"
+    validate: "{{logstash_config_validate_envs}} {{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"
   notify:
    - restart logstash
 
@@ -40,7 +40,7 @@
     owner: root
     group: root
     mode: 0644
-    validate: "{{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"
+    validate: "{{ logstash_config_validate_envs}} {{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"
   notify:
    - restart logstash
 
@@ -53,6 +53,6 @@
     owner: root
     group: root
     mode: 0644
-    validate: "{{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"
+    validate: "{{ logstash_config_validate_envs }} {{ logstash_home }}/bin/logstash {{ logstash_config_validate_params }}"
   notify:
    - restart logstash


### PR DESCRIPTION
we need it to apply `LS_JAVA_OPTS='-Dcom.sun.management.jmxremote.port=$SOME_CRAZY_NUMBER` during deploy because if we don't have such option - deploy will fail with `port already in use` in the case when debug mode is already active in main logstash process. 