### PR TITLE
Customize LS_JVM_OPTS for validate pipeline configs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,6 +55,7 @@ logstash_plugins:
 
 # Options for generate '/etc/logstash/jvm.options'
 logstash_jvm_options: ""
+logstash_jvm_options_path: "{{ logstash_settings_dir }}"
 
 # Options for generate '/etc/logstash/startup.options'
 logstash_startup_options_javacmd: /usr/bin/java

--- a/tasks/050_logstash_pipeline_configuration.yml
+++ b/tasks/050_logstash_pipeline_configuration.yml
@@ -20,6 +20,7 @@
 
 - name: Validate and copy Logstash Input Configuration
   environment:
+    LS_JVM_OPTS: "{{ logstash_jvm_options_path }}"
     LS_JAVA_OPTS: "{{ logstash_java_opts }}"
   template:
     src: input.conf.j2
@@ -33,6 +34,7 @@
 
 - name: Validate and copy Logstash Filter Configuration
   environment:
+    LS_JVM_OPTS: "{{ logstash_jvm_options_path }}"
     LS_JAVA_OPTS: "{{ logstash_java_opts }}"
   template:
     src: filters.conf.j2
@@ -46,6 +48,7 @@
 
 - name: Validate and copy Logstash Output Configuration
   environment:
+    LS_JVM_OPTS: "{{ logstash_jvm_options_path }}"
     LS_JAVA_OPTS: "{{ logstash_java_opts }}"
   template:
     src: output.conf.j2


### PR DESCRIPTION
Subj. 

For example, if you use some:
```
logstash_jvm_options: |
  -Dcom.sun.management.jmxremote
  -Dcom.sun.management.jmxremote.port=5555
```

You pipeline validation will be fail. 

Workaround, use:
```
logstash_jvm_options_path: "/tmp/"
```