### PR TITLE
set false option for DLQ for whole 5 version.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ logstash_custom_vars:
         logstash_dead_letter_queue_enable: true
       }
     - {
-        version: ["5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6"],
+        version: ["5.5", "5.6"],
         apt_repo: "deb https://artifacts.elastic.co/packages/5.x/apt stable main",
         repo_key: "https://artifacts.elastic.co/GPG-KEY-elasticsearch",
         new_way_configure: "True",
@@ -32,6 +32,16 @@ logstash_custom_vars:
         plugin_bin: "logstash-plugin",
         config_validate_params: "--path.settings {{ logstash_settings_dir }} -tf %s",
         logstash_dead_letter_queue_enable: true
+      }
+    - {
+        version: ["5.0", "5.1", "5.2", "5.3", "5.4"],
+        apt_repo: "deb https://artifacts.elastic.co/packages/5.x/apt stable main",
+        repo_key: "https://artifacts.elastic.co/GPG-KEY-elasticsearch",
+        new_way_configure: "True",
+        home_dir: "/usr/share/logstash",
+        plugin_bin: "logstash-plugin",
+        config_validate_params: "--path.settings {{ logstash_settings_dir }} -tf %s",
+        logstash_dead_letter_queue_enable: false
       }
     - {
         version: ["1.5", "2.0", "2.1", "2.2", "2.3", "2.4"],

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,17 +24,7 @@ logstash_custom_vars:
         logstash_dead_letter_queue_enable: true
       }
     - {
-        version: ["5.5", "5.6"],
-        apt_repo: "deb https://artifacts.elastic.co/packages/5.x/apt stable main",
-        repo_key: "https://artifacts.elastic.co/GPG-KEY-elasticsearch",
-        new_way_configure: "True",
-        home_dir: "/usr/share/logstash",
-        plugin_bin: "logstash-plugin",
-        config_validate_params: "--path.settings {{ logstash_settings_dir }} -tf %s",
-        logstash_dead_letter_queue_enable: true
-      }
-    - {
-        version: ["5.0", "5.1", "5.2", "5.3", "5.4"],
+        version: ["5.0", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6"],
         apt_repo: "deb https://artifacts.elastic.co/packages/5.x/apt stable main",
         repo_key: "https://artifacts.elastic.co/GPG-KEY-elasticsearch",
         new_way_configure: "True",


### PR DESCRIPTION
decided to split 5 version into a parts. Because tests failed due to unavailable variable for dead letter queue in logstash config. Since dead letter queue was released in 5.5 version.